### PR TITLE
Add option to automatically load favorites.

### DIFF
--- a/src/API/Core.as
+++ b/src/API/Core.as
@@ -81,6 +81,7 @@ namespace Core {
         auto ps = cast<CSmArenaRulesMode>(GetApp().PlaygroundScript);
         auto dfm = ps.DataFileMgr;
         auto gm = ps.GhostMgr;
+        if (gm is null) return;
         auto task = dfm.Ghost_Download(filename, url);
         WaitAndClearTaskLater(task, dfm);
         if (task.HasFailed || !task.HasSucceeded) {

--- a/src/Main.as
+++ b/src/Main.as
@@ -185,6 +185,12 @@ void OnMapChange() {
     maxTime = 0.;
     if (s_currMap.Length > 0) {
         @g_GhostFinder = GhostFinder();
+        if (S_AutoLoadFav) {
+            log_info("Loading favs");
+            startnew(CoroutineFunc(LoadFavs));
+        } else {
+            log_info("Not loading favs");
+        }
     }
     if (tabs is null) return;
     for (uint i = 0; i < tabs.Length; i++) {
@@ -195,6 +201,23 @@ void OnMapChange() {
     EngineSounds::Unapply();
 }
 
+void LoadFavs() {
+    // TODO: why is this needed?
+    sleep(2000);
+
+    Json::Value@[] players;
+    Cache::Initialize();
+    Cache::GetFavoritesFromNameFilter("", players);
+    for (uint i=0; i<players.Length; i++) {
+        auto player = players[i];
+        string wsid = player['wsid'];
+        string names = string::Join(player['names'].GetKeys(), ", ");
+
+        Update_ML_SetGhostLoading(wsid);
+        Core::LoadGhostOfPlayer(wsid, s_currMap, names);
+        Update_ML_SetGhostLoaded(wsid);
+    }
+}
 
 void WatchAndRemoveFadeOut() {
     auto app = GetApp();

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -37,6 +37,9 @@ bool S_SuppressUnlockTimelinePrompt = false;
 [Setting category="General" name="Hide set offset in advanced tools"]
 bool S_HideSetOffset = true;
 
+[Setting category="General" name="Automatically load favorites"]
+bool S_AutoLoadFav = false;
+
 
 enum KeyboardShape
 {


### PR DESCRIPTION
This is a proof of concept that adds an option to automatically load the ghosts of favorites.

I'm especially not sure, why the sleep is needed (without it sometimes doesn't load all ghosts and triggers the null point exception that is caught by the change in Core).