### PR TITLE
Fixes for Openplanet 1.28.4

### DIFF
--- a/src/API/Core.as
+++ b/src/API/Core.as
@@ -152,7 +152,7 @@ void RenderLoadingGhostsMsg() {
     }
     if (LoadingGhosts_Loading <= 0 && Time::Now > lastRenderLoadingInProg + 500) return;
 
-    auto screen = vec2(Draw::GetWidth(), Draw::GetHeight());
+    auto screen = vec2(Display::GetWidth(), Display::GetHeight());
     auto pos = screen * vec2(.5, .2);
 
     string _loadingStr = "Loading: " + lastRenderLoadingCounts.x + " / " + lastRenderLoadingCounts.y;

--- a/src/GhostEngineSounds.as
+++ b/src/GhostEngineSounds.as
@@ -48,7 +48,7 @@ namespace EngineSounds {
     }
 
     void SetEngineSoundVdBFromSettings_SpawnCoro() {
-        startnew(CoroutineFuncUserdataDouble(EngineSounds::SetEngineSoundVolumeDB), S_EngineSoundsDB);
+        startnew(EngineSounds::SetEngineSoundVolumeDB, S_EngineSoundsDB);
     }
 
     uint lastSetEngineSounds = 0;
@@ -56,7 +56,7 @@ namespace EngineSounds {
         if (lastSetEngineSounds + 100 < Time::Now) {
             double setDb = Math::Lerp(S_EngineSoundsDB, 0.0, Math::Clamp(lerp_t * lerp_t, 0.0, 1.0));
             lastSetEngineSounds = Time::Now;
-            startnew(CoroutineFuncUserdataDouble(EngineSounds::SetEngineSoundVolumeDB), setDb);
+            startnew(EngineSounds::SetEngineSoundVolumeDB, setDb);
         }
     }
 

--- a/src/LetterboxBars.as
+++ b/src/LetterboxBars.as
@@ -10,8 +10,8 @@ void UpdateDrawLetterboxBars() {
 const float lbPctFromEdge = 0.10;
 
 void nvg_DrawLetterbox(float t) {
-    float screenH = Draw::GetHeight();
-    float screenW = Draw::GetWidth();
+    float screenH = Display::GetHeight();
+    float screenW = Display::GetWidth();
     float lbHeight = lbPctFromEdge * screenH;
     float lbTopPos = Math::Lerp(-lbHeight, 0, t);
     float lbBottomPos = Math::Lerp(screenH, screenH - lbHeight, t);

--- a/src/Scrubber.as
+++ b/src/Scrubber.as
@@ -92,7 +92,7 @@ namespace ScrubberWindow {
     void BeforeRender() {
         UI::PushFont(GetCurrFont());
 
-        screen = vec2(Draw::GetWidth(), Draw::GetHeight());
+        screen = vec2(Display::GetWidth(), Display::GetHeight());
         screenScaled = screen / UI::GetScale();
         spacing = UI::GetStyleVarVec2(UI::StyleVar::ItemSpacing);
         fp = UI::GetStyleVarVec2(UI::StyleVar::FramePadding);

--- a/src/ShowInputs.as
+++ b/src/ShowInputs.as
@@ -6,7 +6,7 @@ namespace Inputs {
     float padding = -1;
 
     void DrawInputs(CSceneVehicleVisState@ vis, const vec2 &in size) {
-        if (padding < 0) padding = float(Draw::GetHeight()) * 0.004;
+        if (padding < 0) padding = float(Display::GetHeight()) * 0.004;
         // float _padding =
 
         float steerLeft = vis.InputSteer < 0 ? Math::Abs(vis.InputSteer) : 0.0f;


### PR DESCRIPTION
* Fixes delegates
* Use new `Display` namespace (replaces deprecated `Draw`)

NOTE: These changes need to be published for Openplanet 1.28.4+. Previous versions will throw an exception