### PR TITLE
Game version warning

### DIFF
--- a/src/GameVersionCompat.as
+++ b/src/GameVersionCompat.as
@@ -55,7 +55,13 @@ void EnsureGameVersionCompatibility() {
 }
 
 void WarnBadGameVersion() {
-    NotifyWarning("Game version ("+TmGameVersion+") not marked as compatible with this version of the plugin -- will be inactive!\n\nChecking new versions is a manual process and avoids crashing your game after an update.");
+    NotifyWarning(
+        "This plugin has not been verified to work properly with this game version (" + TmGameVersion + "), "
+        "therefore it's currently disabled.\n\nThere's nothing you need to do - checking new game updates is a "
+        "manual process done by the developer that avoids crashing your game.\n\nTo use the plugin anyway, "
+        "check the last tab of its settings.",
+        15000
+    );
 }
 
 bool requestStarted = true;

--- a/src/GameVersionCompat.as
+++ b/src/GameVersionCompat.as
@@ -60,7 +60,7 @@ void WarnBadGameVersion() {
         "therefore it's currently disabled.\n\nThere's nothing you need to do - checking new game updates is a "
         "manual process done by the developer that avoids crashing your game.\n\nTo use the plugin anyway, "
         "check the last tab of its settings.",
-        15000
+        20000
     );
 }
 

--- a/src/GameVersionCompat.as
+++ b/src/GameVersionCompat.as
@@ -110,12 +110,17 @@ void OverrideGameSafetyCheck_Settings() {
     UI::Text("Game version safe? " + tostring(GameVersionSafe));
     UI::Text("Check request started: " + tostring(requestStarted));
     UI::Text("Check request ended: " + tostring(requestEnded));
-    if (!GameVersionSafe && UI::Button("Disable safety features and run anyway")) {
-        OverrideGameSafetyCheck_GhostsPP();
-    }
-    if (!GameVersionSafe && UI::Button("Disable safety features and run and remember game version")) {
-        OverrideGameSafetyCheck_GhostsPP();
-        S_SavedOkayGameVersion = TmGameVersion;
+    if (!GameVersionSafe) {
+        if (UI::Button("Disable safety features and run anyway")) {
+            OverrideGameSafetyCheck_GhostsPP();
+        }
+        UI::SetItemTooltip("Temporary. Lasts until you restart the game.");
+
+        if (UI::Button("Disable safety features and run and remember game version")) {
+            OverrideGameSafetyCheck_GhostsPP();
+            S_SavedOkayGameVersion = TmGameVersion;
+        }
+        UI::SetItemTooltip("Permanent. Lasts until the game is updated.");
     }
 
     if (GameVersionSafe && S_SavedOkayGameVersion == TmGameVersion) {

--- a/src/Main.as
+++ b/src/Main.as
@@ -321,9 +321,9 @@ void NotifyError(const string &in msg) {
     UI::ShowNotification(Meta::ExecutingPlugin().Name + ": Error", msg, vec4(.9, .3, .1, .3), 12000);
 }
 
-void NotifyWarning(const string &in msg) {
+void NotifyWarning(const string &in msg, const int time = 12000) {
     warn(msg);
-    UI::ShowNotification(Meta::ExecutingPlugin().Name + ": Warning", msg, vec4(.7, .4, .1, .3), 12000);
+    UI::ShowNotification(Meta::ExecutingPlugin().Name + ": Warning", msg, vec4(.7, .4, .1, .3), time);
 }
 
 


### PR DESCRIPTION
We get too many people asking how to fix this plugin because the current game version hasn't been verified. This PR makes the warning message clearer and show for longer on the screen. I also added tooltips to the respective buttons in the settings, clarifying their purpose.

If this looks good to you, I'd be happy to make the same PR for your other plugins that display this message:
https://github.com/XertroV/tm-autohide-opponents
https://github.com/XertroV/tm-ak-hints
https://github.com/XertroV/tm-camera-toggle
https://github.com/XertroV/tm-editor-plus-plus
https://github.com/XertroV/tm-freecam-show-cp
https://github.com/XertroV/tm-item-placement-toolbox
https://github.com/XertroV/tm-skids-magician